### PR TITLE
Pull CUPS in as dependency

### DIFF
--- a/app-editors/atom/atom-1.5.0.ebuild
+++ b/app-editors/atom/atom-1.5.0.ebuild
@@ -30,6 +30,7 @@ DEPEND="
 	x11-libs/libXtst
 	dev-libs/nss
 	media-libs/alsa-lib
+	net-print/cups
 "
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
Atom will fail to start without CUPS installed (happened to me). Apparently the chromium module needs it and it looks like the upstream isn't much interested changing it, at least not anytime soon. Gentoo overlays already have it.

https://github.com/atom/libchromiumcontent/issues/134
